### PR TITLE
Convert qt_opengl example from opengl-cb to render API

### DIFF
--- a/libmpv/qt_opengl/mpvwidget.cpp
+++ b/libmpv/qt_opengl/mpvwidget.cpp
@@ -70,12 +70,12 @@ void MpvWidget::initializeGL()
 
     if (mpv_render_context_create(&mpv_gl, mpv, params) < 0)
         throw std::runtime_error("failed to initialize mpv GL context");
-    mpv_render_context_set_update_callback(mpv_gl, MpvWidget::on_update, (void *)this);
+    mpv_render_context_set_update_callback(mpv_gl, MpvWidget::on_update, reinterpret_cast<void *>(this));
 }
 
 void MpvWidget::paintGL()
 {
-    mpv_opengl_fbo mpfbo{static_cast<int>(defaultFramebufferObject()), fbo->width(), fbo->height(), 0};
+    mpv_opengl_fbo mpfbo{static_cast<int>(defaultFramebufferObject()), width(), height(), 0};
     int flip_y{1};
 
     mpv_render_param params[] = {

--- a/libmpv/qt_opengl/mpvwidget.cpp
+++ b/libmpv/qt_opengl/mpvwidget.cpp
@@ -1,4 +1,4 @@
-#include "mpvwidget.h"
+﻿#include "mpvwidget.h"
 #include <stdexcept>
 #include <QtGui/QOpenGLContext>
 #include <QtCore/QMetaObject>
@@ -12,14 +12,14 @@ static void *get_proc_address(void *ctx, const char *name) {
     Q_UNUSED(ctx);
     QOpenGLContext *glctx = QOpenGLContext::currentContext();
     if (!glctx)
-        return NULL;
-    return (void *)glctx->getProcAddress(QByteArray(name));
+        return nullptr;
+    return reinterpret_cast<void *>(glctx->getProcAddress(QByteArray(name)));
 }
 
 MpvWidget::MpvWidget(QWidget *parent, Qt::WindowFlags f)
     : QOpenGLWidget(parent, f)
 {
-    mpv = mpv::qt::Handle::FromRawHandle(mpv_create());
+    mpv = mpv_create();
     if (!mpv)
         throw std::runtime_error("could not create mpv context");
 
@@ -28,17 +28,8 @@ MpvWidget::MpvWidget(QWidget *parent, Qt::WindowFlags f)
     if (mpv_initialize(mpv) < 0)
         throw std::runtime_error("could not initialize mpv context");
 
-    // Make use of the MPV_SUB_API_OPENGL_CB API.
-    mpv::qt::set_option_variant(mpv, "vo", "opengl-cb");
-
     // Request hw decoding, just for testing.
     mpv::qt::set_option_variant(mpv, "hwdec", "auto");
-
-    mpv_gl = (mpv_opengl_cb_context *)mpv_get_sub_api(mpv, MPV_SUB_API_OPENGL_CB);
-    if (!mpv_gl)
-        throw std::runtime_error("OpenGL not compiled in");
-    mpv_opengl_cb_set_update_callback(mpv_gl, MpvWidget::on_update, (void *)this);
-    connect(this, SIGNAL(frameSwapped()), SLOT(swapped()));
 
     mpv_observe_property(mpv, 0, "duration", MPV_FORMAT_DOUBLE);
     mpv_observe_property(mpv, 0, "time-pos", MPV_FORMAT_DOUBLE);
@@ -49,11 +40,8 @@ MpvWidget::~MpvWidget()
 {
     makeCurrent();
     if (mpv_gl)
-        mpv_opengl_cb_set_update_callback(mpv_gl, NULL, NULL);
-    // Until this call is done, we need to make sure the player remains
-    // alive. This is done implicitly with the mpv::qt::Handle instance
-    // in this class.
-    mpv_opengl_cb_uninit_gl(mpv_gl);
+        mpv_render_context_free(mpv_gl);
+    mpv_terminate_destroy(mpv);
 }
 
 void MpvWidget::command(const QVariant& params)
@@ -73,19 +61,31 @@ QVariant MpvWidget::getProperty(const QString &name) const
 
 void MpvWidget::initializeGL()
 {
-    int r = mpv_opengl_cb_init_gl(mpv_gl, NULL, get_proc_address, NULL);
-    if (r < 0)
-        throw std::runtime_error("could not initialize OpenGL");
+    mpv_opengl_init_params gl_init_params{get_proc_address, nullptr, nullptr};
+    mpv_render_param params[]{
+        {MPV_RENDER_PARAM_API_TYPE, const_cast<char *>(MPV_RENDER_API_TYPE_OPENGL)},
+        {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init_params},
+        {MPV_RENDER_PARAM_INVALID, nullptr}
+    };
+
+    if (mpv_render_context_create(&mpv_gl, mpv, params) < 0)
+        throw std::runtime_error("failed to initialize mpv GL context");
+    mpv_render_context_set_update_callback(mpv_gl, MpvWidget::on_update, (void *)this);
 }
 
 void MpvWidget::paintGL()
 {
-    mpv_opengl_cb_draw(mpv_gl, defaultFramebufferObject(), width(), -height());
-}
+    mpv_opengl_fbo mpfbo{static_cast<int>(defaultFramebufferObject()), fbo->width(), fbo->height(), 0};
+    int flip_y{1};
 
-void MpvWidget::swapped()
-{
-    mpv_opengl_cb_report_flip(mpv_gl, 0);
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_OPENGL_FBO, &mpfbo},
+        {MPV_RENDER_PARAM_FLIP_Y, &flip_y},
+        {MPV_RENDER_PARAM_INVALID, nullptr}
+    };
+    // See render_gl.h on what OpenGL environment mpv expects, and
+    // other API details.
+    mpv_render_context_render(mpv_gl, params);
 }
 
 void MpvWidget::on_mpv_events()
@@ -137,7 +137,6 @@ void MpvWidget::maybeUpdate()
         makeCurrent();
         paintGL();
         context()->swapBuffers(context()->surface());
-        swapped();
         doneCurrent();
     } else {
         update();

--- a/libmpv/qt_opengl/mpvwidget.h
+++ b/libmpv/qt_opengl/mpvwidget.h
@@ -3,7 +3,7 @@
 
 #include <QtWidgets/QOpenGLWidget>
 #include <mpv/client.h>
-#include <mpv/opengl_cb.h>
+#include <mpv/render_gl.h>
 #include <mpv/qthelper.hpp>
 
 class MpvWidget Q_DECL_FINAL: public QOpenGLWidget
@@ -23,15 +23,14 @@ protected:
     void initializeGL() Q_DECL_OVERRIDE;
     void paintGL() Q_DECL_OVERRIDE;
 private Q_SLOTS:
-    void swapped();
     void on_mpv_events();
     void maybeUpdate();
 private:
     void handle_mpv_event(mpv_event *event);
     static void on_update(void *ctx);
 
-    mpv::qt::Handle mpv;
-    mpv_opengl_cb_context *mpv_gl;
+    mpv_handle *mpv;
+    mpv_render_context *mpv_gl;
 };
 
 


### PR DESCRIPTION
Can be compiled successfully using the latest mpv headers and Qt 5.11.1 + MSVC2017 15.7 on Windows.