### PR TITLE
Example libmpv c++ api embedding in wid

### DIFF
--- a/libmpv/embedinwid/libexample.cpp
+++ b/libmpv/embedinwid/libexample.cpp
@@ -1,0 +1,137 @@
+/*
+
+ MIT License
+ 
+ Copyright © 2020 Samuel Venable
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ 
+*/
+
+#include "videoplayer.h"
+
+using std::string;
+
+#ifdef _WIN32 /* Windows */
+#define EXPORTED_FUNCTION extern "C" __declspec(dllexport)
+#else /* Linux, macOS, and FreeBSD */
+#define EXPORTED_FUNCTION extern "C" __attribute__((visibility("default"))) 
+#endif
+
+EXPORTED_FUNCTION void splash_set_stop_mouse(bool stop) {
+  videoplayer::splash_set_stop_mouse(stop);
+}
+
+EXPORTED_FUNCTION void splash_set_stop_key(bool stop) {
+  videoplayer::splash_set_stop_key(stop);
+}
+
+EXPORTED_FUNCTION void splash_set_window(char *wid) {
+  videoplayer::splash_set_window(wid);
+}
+
+EXPORTED_FUNCTION void splash_set_volume(int vol) {
+  videoplayer::splash_set_volume(vol);
+}
+
+EXPORTED_FUNCTION void splash_show_video(char *fname, bool loop) {
+  videoplayer::splash_show_video(fname, loop);
+}
+
+EXPORTED_FUNCTION char *video_add(char *fname) {
+  static string result;
+  result = videoplayer::video_add(fname);
+  return (char *)result.c_str();
+}
+
+EXPORTED_FUNCTION bool video_get_option_was_set(char *ind, char *option) {
+  return videoplayer::video_get_option_was_set(ind, option);
+}
+
+EXPORTED_FUNCTION char *video_get_option_string(char *ind, char *option) {
+  static string result;
+  result = videoplayer::video_get_option_string(ind, option);
+  return (char *)result.c_str();
+}
+
+EXPORTED_FUNCTION void video_set_option_string(char *ind, char *option, char *value) {
+  videoplayer::video_set_option_string(ind, option, value);
+}
+
+EXPORTED_FUNCTION void video_play(char *ind) {
+  videoplayer::video_play(ind);
+}
+
+EXPORTED_FUNCTION bool video_is_paused(char *ind) {
+  return videoplayer::video_is_paused(ind);
+}
+
+EXPORTED_FUNCTION bool video_is_playing(char *ind) {
+  return videoplayer::video_is_playing(ind);
+}
+
+EXPORTED_FUNCTION int video_get_volume_percent(char *ind) {
+  return videoplayer::video_get_volume_percent(ind);
+}
+
+EXPORTED_FUNCTION void video_set_volume_percent(char *ind, int volume) {
+  videoplayer::video_set_volume_percent(ind, volume);
+}
+
+EXPORTED_FUNCTION char *video_get_window_identifier(char *ind) {
+  static string result;
+  result = videoplayer::video_get_window_identifier(ind);
+  return (char *)result.c_str();
+}
+
+EXPORTED_FUNCTION void video_set_window_identifier(char *ind, char *wid) {
+  videoplayer::video_set_window_identifier(ind, wid);
+}
+
+EXPORTED_FUNCTION bool video_exists(char *ind) {
+  return videoplayer::video_exists(ind);
+}
+
+EXPORTED_FUNCTION void video_pause(char *ind) {
+  videoplayer::video_pause(ind);
+}
+
+EXPORTED_FUNCTION void video_stop(char *ind) {
+  videoplayer::video_stop(ind);
+}
+
+EXPORTED_FUNCTION unsigned video_get_width(char *ind) {
+  return videoplayer::video_get_width(ind);
+}
+
+EXPORTED_FUNCTION unsigned video_get_height(char *ind) {
+  return videoplayer::video_get_height(ind);
+}
+
+EXPORTED_FUNCTION double video_get_position(char *ind) {
+  return videoplayer::video_get_position(ind);
+}
+
+EXPORTED_FUNCTION double video_get_duration(char *ind) {
+  return videoplayer::video_get_duration(ind);
+}
+
+EXPORTED_FUNCTION void video_delete(char *ind) {
+  videoplayer::video_delete(ind);
+}

--- a/libmpv/embedinwid/libexample.cpp
+++ b/libmpv/embedinwid/libexample.cpp
@@ -29,9 +29,9 @@
 using std::string;
 
 #ifdef _WIN32 /* Windows */
-#define EXPORTED_FUNCTION extern "C" __declspec(dllexport)
+  #define EXPORTED_FUNCTION extern "C" __declspec(dllexport)
 #else /* Linux, macOS, and FreeBSD */
-#define EXPORTED_FUNCTION extern "C" __attribute__((visibility("default"))) 
+  #define EXPORTED_FUNCTION extern "C" __attribute__((visibility("default"))) 
 #endif
 
 EXPORTED_FUNCTION void splash_set_stop_mouse(bool stop) {

--- a/libmpv/embedinwid/videoplayer.cpp
+++ b/libmpv/embedinwid/videoplayer.cpp
@@ -1,0 +1,326 @@
+/*
+
+ MIT License
+ 
+ Copyright © 2020 Samuel Venable
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ 
+*/
+
+#include <climits>
+#include <fstream>
+#include <cstdio>
+#include <string>
+#include <thread>
+#include <map>
+
+#ifndef __APPLE__
+  #include <chrono>
+#endif
+
+#include "videoplayer.h"
+
+#ifdef _WIN32
+  #include <windows.h>
+#endif
+
+#include <mpv/client.h>
+
+using std::string;
+
+struct VideoData {
+  mpv_handle *mpv;
+  std::map<string, string> option;
+  string window_id;
+  int volume;
+  bool is_paused;
+  bool is_playing;
+};
+
+static std::map<string, VideoData> videos;
+static string video, mpv_wid       = "0";
+static string splash_get_window    = "0";
+static int splash_get_volume       = 100;
+static bool splash_get_stop_mouse  = true;
+static bool splash_get_stop_key    = true;
+
+#ifdef __APPLE__
+  #ifdef __MACH__
+     extern "C" void cocoa_show_cursor();
+     extern "C" const char *cocoa_prefer_global_windowid(const char *window);
+     extern "C" const char *cocoa_window_get_contentview(const char *window);
+     extern "C" void cocoa_process_run_loop(const char *video, 
+       const char *window, bool close_mouse, bool close_key);
+  #endif
+#endif
+
+static void video_loop(string ind, mpv_handle *mpv) {
+  while (true) {
+    mpv_event *event = mpv_wait_event(mpv, -1);
+    if (event->event_id == MPV_EVENT_END_FILE) break;
+    if (event->event_id == MPV_EVENT_SHUTDOWN) break;
+  }
+  videos[ind].is_playing = false;
+  mpv_terminate_destroy(mpv);
+}
+
+namespace videoplayer {
+
+void splash_set_window(string wid) {
+  wid = std::to_string(strtoull(wid.c_str(), NULL, 10));
+  splash_get_window = wid;
+}
+
+void splash_set_stop_mouse(bool stop) {
+  splash_get_stop_mouse = stop;
+}
+
+void splash_set_stop_key(bool stop) {
+  splash_get_stop_key = stop;
+}
+
+void splash_set_volume(int vol) {
+  splash_get_volume = vol;
+}
+
+void splash_show_video(string fname, bool loop) {
+  string wid, looping;
+  #ifdef __APPLE__
+    #ifdef __MACH__
+      wid = cocoa_prefer_global_windowid(splash_get_window.c_str());
+      wid = cocoa_window_get_contentview(wid.c_str());
+    #endif
+  #else
+    wid = splash_get_window;
+  #endif
+  looping = loop ? "yes" : "no";
+  if (video_exists(video)) {
+    video_delete(video);
+  }
+  video = video_add(fname);
+  #if defined(__linux__) || defined(__FreeBSD__)
+    std::remove(("/tmp/mpv-input-" + wid + ".conf").c_str());
+    std::ofstream file;
+    file.open(("/tmp/mpv-input-" + wid + ".conf").c_str());
+    if (splash_get_stop_key) {
+      file << "ESC quit\n";
+    }
+    if (splash_get_stop_mouse) {
+      file << "MBTN_LEFT quit\n";
+      file << "MBTN_RIGHT quit\n";
+    }
+    file.close();
+    video_set_option_string(video, "input-conf", 
+      ("/tmp/mpv-input-" + wid + ".conf").c_str());
+  #endif
+  video_set_option_string(video, "volume", std::to_string(splash_get_volume));
+  video_set_option_string(video, "input-default-bindings", "no");
+  video_set_option_string(video, "cursor-autohide", "always");
+  video_set_option_string(video, "input-vo-keyboard", "yes");
+  video_set_option_string(video, "taskbar-progress", "no");
+  video_set_option_string(video, "loop", looping);
+  video_set_option_string(video, "config", "no");
+  video_set_option_string(video, "osc", "no");
+  video_set_option_string(video, "wid", wid);
+  video_play(video);
+  #ifdef _WIN32
+    bool hidden = false;
+  #endif
+  while (video_is_playing(video)) {
+    #ifdef __APPLE__
+      #ifdef __MACH__
+        cocoa_process_run_loop(video.c_str(), wid.c_str(),
+          splash_get_stop_mouse, splash_get_stop_key);
+      #endif
+    #else
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      #ifdef _WIN32
+        MSG msg;
+        while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
+          TranslateMessage(&msg);
+          DispatchMessage(&msg);
+          if (wid == std::to_string((unsigned long long)msg.hwnd)) {
+            if (splash_get_stop_mouse) {
+              if (msg.message == WM_LBUTTONDOWN || msg.message == WM_RBUTTONDOWN ||
+                msg.message == WM_NCLBUTTONDOWN || msg.message == WM_NCRBUTTONDOWN) {
+                video_stop(video);
+              }
+            }
+            if (splash_get_stop_key) {
+              if (msg.message == WM_KEYDOWN && msg.wParam == VK_ESCAPE) {
+                video_stop(video);
+              }
+            }
+            POINT point;
+            GetCursorPos(&point);
+            if (msg.hwnd == WindowFromPoint(point)) {
+              if (!hidden) {
+                ShowCursor(false);
+                hidden = true;
+              }
+            } else {
+              if (hidden) {
+                ShowCursor(true);
+                hidden = false;
+              }
+            }
+          }
+        }
+      #endif
+    #endif
+  }
+  #ifdef _WIN32
+  if (hidden) {
+    ShowCursor(true);
+    hidden = false;
+  }
+  #endif
+  #ifdef __APPLE__
+    #ifdef __MACH__
+      cocoa_show_cursor();
+    #endif
+  #endif
+}
+
+string video_add(string fname) {
+  VideoData data;
+  data.mpv        = mpv_create();
+  data.window_id  = mpv_wid;
+  data.volume     = 100;
+  data.is_paused  = false;
+  data.is_playing = false;
+  videos.insert(std::make_pair(fname, data));
+  return fname;
+}
+
+bool video_get_option_was_set(string ind, string option) {
+  return (videos[ind].option.find(option) != videos[ind].option.end());
+}
+
+string video_get_option_string(string ind, string option) {
+  bool was_set = video_get_option_was_set(ind, option);
+  return was_set ? videos[ind].option.find(option)->second : "";
+}
+
+void video_set_option_string(string ind, string option, string value) {
+  if (option == "wid") value = std::to_string(strtoull(value.c_str(), NULL, 10));
+  mpv_set_option_string(videos[ind].mpv, option.c_str(), value.c_str());
+  if (!video_get_option_was_set(ind, option)) {
+    videos[ind].option.insert(std::make_pair(option, value));
+  } else {
+    videos[ind].option[option] = value;
+  }
+}
+
+void video_play(string ind) {
+  videos[ind].is_playing = true;
+  mpv_initialize(videos[ind].mpv);
+  const char *cmd[] = { "loadfile", ind.c_str(), NULL };
+  mpv_command(videos[ind].mpv, cmd);
+  std::thread stringthread(video_loop, ind, videos[ind].mpv);
+  stringthread.detach();
+}
+
+bool video_is_paused(string ind) {
+  if (videos.find(ind) != videos.end())
+    return videos[ind].is_paused;
+  return false;
+}
+
+bool video_is_playing(string ind) {
+  if (videos.find(ind) != videos.end())
+    return videos[ind].is_playing;
+  return false;
+}
+
+int video_get_volume_percent(string ind) {
+  if (video_get_option_was_set(ind, "volume"))
+    return videos[ind].volume;
+  return 100;
+}
+
+void video_set_volume_percent(string ind, int volume) {
+  videos[ind].volume = volume;
+  video_set_option_string(ind, "volume", std::to_string(volume));
+}
+
+string video_get_window_identifier(string ind) {
+  if (video_get_option_was_set(ind, "wid"))
+    return videos[ind].window_id;
+  return "0";
+}
+
+void video_set_window_identifier(string ind, string wid) {
+  wid = std::to_string(strtoull(wid.c_str(), NULL, 10));
+  #ifdef __APPLE__
+    #ifdef __MACH__
+      wid = cocoa_prefer_global_windowid(wid.c_str());
+      wid = cocoa_window_get_contentview(wid.c_str());
+    #endif
+  #endif
+  videos[ind].window_id = wid;
+  video_set_option_string(ind, "wid", wid);
+}
+
+bool video_exists(string ind) {
+  return (videos.find(ind) != videos.end());
+}
+
+void video_pause(string ind) {
+  const char *cmd[] = { "cycle", "pause", NULL };
+  mpv_command_async(videos[ind].mpv, 0, cmd);
+  videos[ind].is_paused = !video_is_paused(ind);
+}
+
+void video_stop(string ind) {
+  const char *cmd[] = { "quit", NULL, NULL };
+  mpv_command_async(videos[ind].mpv, 0, cmd);
+  videos[ind].is_playing = false;
+}
+
+void video_delete(string ind) {
+  videos.erase(ind);
+}
+
+unsigned video_get_width(string ind) {
+  long long result;
+  mpv_get_property(videos[ind].mpv, "width", MPV_FORMAT_INT64, &result);
+  return (unsigned)result;
+}
+
+unsigned video_get_height(string ind) {
+  long long result;
+  mpv_get_property(videos[ind].mpv, "height", MPV_FORMAT_INT64, &result);
+  return (unsigned)result;
+}
+
+double video_get_position(string ind) { 
+  double result;
+  mpv_get_property(videos[ind].mpv, "time-pos", MPV_FORMAT_DOUBLE, &result);
+  return result;
+}
+
+double video_get_duration(string ind) {
+  double result;
+  mpv_get_property(videos[ind].mpv, "duration", MPV_FORMAT_DOUBLE, &result);
+  return result;
+}
+
+} // namespace videoplayer

--- a/libmpv/embedinwid/videoplayer.h
+++ b/libmpv/embedinwid/videoplayer.h
@@ -1,0 +1,65 @@
+/*
+
+ MIT License
+ 
+ Copyright © 2020 Samuel Venable
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ 
+*/
+
+#ifdef __cplusplus
+
+#include <string>
+
+namespace videoplayer {
+
+void splash_set_volume(int vol);
+void splash_set_window(std::string wid);
+void splash_set_stop_mouse(bool stop);
+void splash_set_stop_key(bool stop);
+void splash_show_video(std::string fname, bool loop);
+
+std::string video_add(std::string fname);
+bool video_get_option_was_set(std::string ind, std::string option);
+std::string video_get_option_string(std::string ind, std::string option);
+void video_set_option_string(std::string ind, std::string option, std::string value);
+void video_play(std::string ind);
+bool video_is_paused(std::string ind);
+bool video_is_playing(std::string ind);
+int video_get_volume_percent(std::string ind);
+void video_set_volume_percent(std::string ind, int volume);
+std::string video_get_window_identifier(std::string ind);
+void video_set_window_identifier(std::string ind, std::string wid);
+void video_pause(std::string ind);
+void video_stop(std::string ind);
+unsigned video_get_width(std::string ind);
+unsigned video_get_height(std::string ind);
+double video_get_position(std::string ind);
+double video_get_duration(std::string ind);
+bool video_exists(std::string ind);
+void video_delete(std::string ind);
+
+} // namespace videoplayer
+
+#else
+
+void video_stop(const char *ind);
+
+#endif

--- a/libmpv/embedinwid/videoplayer.mm
+++ b/libmpv/embedinwid/videoplayer.mm
@@ -1,0 +1,82 @@
+/*
+
+ MIT License
+ 
+ Copyright © 2020 Samuel Venable
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ 
+*/
+
+#import <string.h>
+
+#import <Cocoa/Cocoa.h>
+#import <Carbon/Carbon.h>
+
+#import "videoplayer.h"
+
+bool hidden = false;
+
+const char *cocoa_window_get_contentview(const char *window) {
+  NSWindow *win = (NSWindow *)strtoull(window, NULL, 10);
+  unsigned long long ull = (unsigned long long)[win contentView];
+  return [[NSString stringWithFormat:@"%llu", ull] UTF8String];
+}
+
+void cocoa_show_cursor() {
+  if (hidden) {
+    [NSCursor unhide];
+    hidden = false;
+  }
+}
+
+const char *cocoa_prefer_global_windowid(const char *window) {
+  unsigned long long ull = strtoull(window, NULL, 10);
+  if ([NSApp windowWithWindowNumber:(unsigned long)ull] != nil) {
+    return [[NSString stringWithFormat:@"%llu",
+      (unsigned long long)[NSApp windowWithWindowNumber:
+      (unsigned long)ull]] UTF8String];
+  }
+  return window;
+}
+
+void cocoa_process_run_loop(const char *video,
+  const char *window, bool close_mouse, bool close_key) {
+  [[NSRunLoop currentRunLoop] acceptInputForMode:NSModalPanelRunLoopMode
+  beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.005]];
+  NSPoint mouseLoc; mouseLoc = [NSEvent mouseLocation];
+  CGWindowID windowNumber = [NSWindow
+    windowNumberAtPoint:mouseLoc belowWindowWithWindowNumber:0];
+  NSView *view = (NSView *)strtoull(window, NULL, 10);
+  CGWindowID wid = [[view window] windowNumber];
+  if (windowNumber == wid) {
+    if (!hidden) { [NSCursor hide]; hidden = true; }
+    if (close_mouse && ([NSEvent pressedMouseButtons] == 1 << 0 ||
+      [NSEvent pressedMouseButtons] == 1 << 1)) {
+      video_stop(video);
+    }
+  } else {
+    cocoa_show_cursor();
+  }
+  NSEvent *event = [[view window] nextEventMatchingMask:NSEventMaskAny
+    untilDate:[NSDate distantPast] inMode:NSModalPanelRunLoopMode dequeue:YES];
+  if ([event type] == 10 && [event keyCode] == kVK_Escape) {
+    video_stop(video);
+  }
+}


### PR DESCRIPTION
On macOS, you can either use a global CGWindowID, or an NSWindow * casted to an uintptr_t. In either case, you will need to wrap the resulting integer in a string with std::to_string or however you prefer. If an NSWindow * was intented to be passed but the integer is equal to an existing CGWindowID that belongs to the app, prefer the CGWindowID in the case of such conflict. Thus, it is probably better to pass the CGWindowID via [NSWindow windowNumber] if you're paranoid about obscure results.

If the specified CGWindowID does not belong to the current app, the passed value will be treated as an NSWindow, make sure you only pass a CGWindowID that belongs to the current application process. Supports Windows, macOS, Linux, and FreeBSD out of the box. OpenBSD, NetBSD, DragonflyBSD, other *BSD's, and (I think?) Solaris/OpenSolaris might also be viable with just a matter of adding more platform macro checks to the X11/Wayland related code, which I'm happy to add on request.

No Android/iOS support; don't develop for mobile. Others can add that in if they want, and if they do they can be added to the copyright header. I am using unsigned long long instead of uintptr_t, if that is a problem or a deal breaker then let me know and I'll change it. Splash functions are synchronous and hide the cursor, you have the option to loop the video as well as close it with either the escape key or the left/right mouse button. The other video functions are asynchronous, use multi-threading, and more options.

Code is based on: https://github.com/time-killer-games/libvidplayer